### PR TITLE
Allowing alerts to accept icons before text.

### DIFF
--- a/ohsnap.js
+++ b/ohsnap.js
@@ -8,7 +8,7 @@
  * copyright - nice copyright over here
  */
 
-function ohSnap(text, color) {
+function ohSnap(icon, text, color) {
   // text : message to show (HTML tag allowed)
   // Available colors : red, green, blue, orange, yellow --- add your own!
   
@@ -17,7 +17,7 @@ function ohSnap(text, color) {
   var $container = $('#ohsnap');
 
   // Generate the HTML
-  var html = '<div class="alert alert-' + color + '">' + text + '</div>';
+  var html = '<div class="alert alert-' + color + '"><span class="' + icon + '"></span> ' + text + '</div>';
 
   // Append the label to the container
   $container.append(html);


### PR DESCRIPTION
One more parameter to pass:

// This will render a question point before text:
ohSnap('glyphicon glyphicon-question-sign', 'Oh Snap! I cannot process your card...', 'red');

// No icon to show, just pass '' or null:
ohSnap('', 'Oh Snap! I cannot process your card...', 'red');
