### PR TITLE
Update ohsnap.js

### DIFF
--- a/ohsnap.js
+++ b/ohsnap.js
@@ -41,6 +41,6 @@ function ohSnapX(element) {
 
 // Remove the notification on click
 
-$('.alert').live('click', function() { 
+$('.alert').on('click', function() { 
   ohSnapX($(this))
 });


### PR DESCRIPTION
Changed the Deprecated live event to jQuery on()
